### PR TITLE
fix: define a name for jobs

### DIFF
--- a/src/KafkaFlow.Retry.UnitTests/KafkaFlow.Retry/Durable/Polling/QueueTrackerFactoryTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/KafkaFlow.Retry/Durable/Polling/QueueTrackerFactoryTests.cs
@@ -2,8 +2,13 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using FluentAssertions;
+    using global::KafkaFlow.Retry.Durable.Definitions.Polling;
+    using global::KafkaFlow.Retry.Durable.Encoders;
     using global::KafkaFlow.Retry.Durable.Polling;
+    using global::KafkaFlow.Retry.Durable.Repository;
+    using global::KafkaFlow.Retry.Durable.Repository.Adapters;
     using Moq;
     using Xunit;
 
@@ -47,6 +52,45 @@
 
             // Arrange
             queueTracker.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task QueueTrackerFactory_Reschedule_Success()
+        {
+            var mockILogHandler = new Mock<ILogHandler>();
+            mockILogHandler.Setup(x => x.Info(It.IsAny<string>(), It.IsAny<object>()));
+            mockILogHandler.Setup(x => x.Error(It.IsAny<string>(), It.IsAny<Exception>(), It.IsAny<object>()));
+
+            var mockIMessageProducer = new Mock<IMessageProducer>();
+
+            var pollingDefinitionsAggregator =
+                new PollingDefinitionsAggregator(
+                    "topic",
+                    new List<PollingDefinition>
+                    {
+                        new CleanupPollingDefinition(true, "*/5 * * ? * * *",1,1),
+                        new RetryDurablePollingDefinition(true, "*/5 * * ? * * *",1,1)
+                    });
+
+            var queueTrackerCoordinator =
+                new QueueTrackerCoordinator(
+                    new QueueTrackerFactory(
+                        pollingDefinitionsAggregator.SchedulerId,
+                        new JobDataProvidersFactory(
+                            pollingDefinitionsAggregator,
+                            new TriggerProvider(),
+                            new NullRetryDurableQueueRepository(),
+                            new MessageHeadersAdapter(),
+                            new Utf8Encoder()
+                        )
+                    )
+                );
+
+            await queueTrackerCoordinator.ScheduleJobsAsync(mockIMessageProducer.Object, mockILogHandler.Object).ConfigureAwait(false);
+            await queueTrackerCoordinator.UnscheduleJobsAsync().ConfigureAwait(false);
+            await queueTrackerCoordinator.ScheduleJobsAsync(mockIMessageProducer.Object, mockILogHandler.Object).ConfigureAwait(false);
+
+            mockILogHandler.Verify(x => x.Error(It.IsAny<string>(), It.IsAny<Exception>(), It.IsAny<object>()), Times.Never);
         }
 
         [Theory]

--- a/src/KafkaFlow.Retry/Durable/Polling/Jobs/RetryDurableJobDataProvider.cs
+++ b/src/KafkaFlow.Retry/Durable/Polling/Jobs/RetryDurableJobDataProvider.cs
@@ -52,21 +52,20 @@
         public ITrigger Trigger => this.trigger;
 
         public IJobDetail GetPollingJobDetail()
-        {
-            var dataMap = new JobDataMap();
-
-            dataMap.Add(PollingJobConstants.RetryDurablePollingDefinition, this.retryDurablePollingDefinition);
-            dataMap.Add(PollingJobConstants.SchedulerId, this.schedulerId);
-            dataMap.Add(PollingJobConstants.RetryDurableQueueRepository, this.retryDurableQueueRepository);
-            dataMap.Add(PollingJobConstants.LogHandler, this.logHandler);
-            dataMap.Add(PollingJobConstants.MessageHeadersAdapter, this.messageHeadersAdapter);
-            dataMap.Add(PollingJobConstants.Utf8Encoder, this.utf8Encoder);
-            dataMap.Add(PollingJobConstants.RetryDurableMessageProducer, this.retryDurableMessageProducer);
-
-            return JobBuilder
+            => JobBuilder
                 .Create<RetryDurablePollingJob>()
-                .SetJobData(dataMap)
+                .WithIdentity($"pollingJob_{this.schedulerId}_{this.retryDurablePollingDefinition.PollingJobType}", "queueTrackerGroup")
+                .SetJobData(
+                    new JobDataMap
+                    {
+                        { PollingJobConstants.RetryDurablePollingDefinition, this.retryDurablePollingDefinition },
+                        { PollingJobConstants.SchedulerId, this.schedulerId },
+                        { PollingJobConstants.RetryDurableQueueRepository, this.retryDurableQueueRepository },
+                        { PollingJobConstants.LogHandler, this.logHandler },
+                        { PollingJobConstants.MessageHeadersAdapter, this.messageHeadersAdapter },
+                        { PollingJobConstants.Utf8Encoder, this.utf8Encoder },
+                        { PollingJobConstants.RetryDurableMessageProducer, this.retryDurableMessageProducer }
+                    })
                 .Build();
-        }
     }
 }

--- a/src/KafkaFlow.Retry/Durable/Polling/TriggerProvider.cs
+++ b/src/KafkaFlow.Retry/Durable/Polling/TriggerProvider.cs
@@ -1,38 +1,17 @@
 ﻿namespace KafkaFlow.Retry.Durable.Polling
 {
-    using System.Collections.Generic;
     using KafkaFlow.Retry.Durable.Definitions.Polling;
     using Quartz;
 
     internal class TriggerProvider : ITriggerProvider
     {
-        private readonly IDictionary<string, ITrigger> triggers;
-
-        public TriggerProvider()
-        {
-            this.triggers = new Dictionary<string, ITrigger>();
-        }
-
         public ITrigger GetPollingTrigger(string schedulerId, PollingDefinition pollingDefinition)
-        {
-            var triggerId = $"pollingJobTrigger_{schedulerId}_{pollingDefinition.PollingJobType}";
-
-            if (this.triggers.TryGetValue(triggerId, out var triggerAlreadyCreated))
-            {
-                return triggerAlreadyCreated;
-            }
-
-            var trigger = TriggerBuilder
-                            .Create()
-                            .WithIdentity(triggerId, "queueTrackerGroup")
-                            .WithCronSchedule(pollingDefinition.CronExpression)
-                            .StartNow()
-                            .WithPriority(1)
-                            .Build();
-
-            this.triggers.Add(triggerId, trigger);
-
-            return trigger;
-        }
+            => TriggerBuilder
+                .Create()
+                .WithIdentity($"pollingJobTrigger_{schedulerId}_{pollingDefinition.PollingJobType}", "queueTrackerGroup")
+                .WithCronSchedule(pollingDefinition.CronExpression)
+                .StartNow()
+                .WithPriority(1)
+                .Build();
     }
 }


### PR DESCRIPTION
# Description

It fixes problem #109 .
The problem was the lack of the job's name. 
When no jobs name is defined, quartz sets a random name. Then. when the scheduler is fired the trigger is related to the jobs name. As the trigger is set once on reschedule it does not use the job random job's name. 

Fixes #109 

## How Has This Been Tested?

We did a unit test to cover this beahvior.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
