### PR TITLE
Adding prefix endpoint to retry

### DIFF
--- a/src/KafkaFlow.Retry.API/AppBuilderExtensions.cs
+++ b/src/KafkaFlow.Retry.API/AppBuilderExtensions.cs
@@ -18,14 +18,30 @@
                     .ApplicationServices
                     .GetService(typeof(IRetryDurableQueueRepositoryProvider)) as IRetryDurableQueueRepositoryProvider;
 
-            appBuilder.UseRetryEndpoints(retryDurableQueueRepositoryProvider);
+            appBuilder.UseRetryEndpoints(retryDurableQueueRepositoryProvider, string.Empty);
+
+            return appBuilder;
+        }
+
+        public static IApplicationBuilder UseKafkaFlowRetryEndpoints(
+           this IApplicationBuilder appBuilder,
+           string endpointPrefix
+       )
+        {
+            var retryDurableQueueRepositoryProvider =
+                appBuilder
+                    .ApplicationServices
+                    .GetService(typeof(IRetryDurableQueueRepositoryProvider)) as IRetryDurableQueueRepositoryProvider;
+
+            appBuilder.UseRetryEndpoints(retryDurableQueueRepositoryProvider, endpointPrefix);
 
             return appBuilder;
         }
 
         public static IApplicationBuilder UseRetryEndpoints(
                     this IApplicationBuilder appBuilder,
-            IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider
+            IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider,
+            string endpointPrefix
         )
         {
             appBuilder.UseMiddleware<RetryMiddleware>(
@@ -33,19 +49,22 @@
                     retryDurableQueueRepositoryProvider,
                     new GetItemsRequestDtoReader(),
                     new GetItemsInputAdapter(),
-                    new GetItemsResponseDtoAdapter()));
+                    new GetItemsResponseDtoAdapter(),
+                    endpointPrefix));
 
             appBuilder.UseMiddleware<RetryMiddleware>(
                 new PatchItemsHandler(
                     retryDurableQueueRepositoryProvider,
                     new UpdateItemsInputAdapter(),
-                    new UpdateItemsResponseDtoAdapter()));
+                    new UpdateItemsResponseDtoAdapter(),
+                    endpointPrefix));
 
             appBuilder.UseMiddleware<RetryMiddleware>(
                 new PatchQueuesHandler(
                     retryDurableQueueRepositoryProvider,
                     new UpdateQueuesInputAdapter(),
-                    new UpdateQueuesResponseDtoAdapter()));
+                    new UpdateQueuesResponseDtoAdapter(),
+                    endpointPrefix));
 
             return appBuilder;
         }

--- a/src/KafkaFlow.Retry.API/AppBuilderExtensions.cs
+++ b/src/KafkaFlow.Retry.API/AppBuilderExtensions.cs
@@ -9,24 +9,10 @@
 
     public static class AppBuilderExtensions
     {
-        public static IApplicationBuilder UseKafkaFlowRetryEndpoints(
-            this IApplicationBuilder appBuilder
-        )
-        {
-            var retryDurableQueueRepositoryProvider =
-                appBuilder
-                    .ApplicationServices
-                    .GetService(typeof(IRetryDurableQueueRepositoryProvider)) as IRetryDurableQueueRepositoryProvider;
-
-            appBuilder.UseRetryEndpoints(retryDurableQueueRepositoryProvider, string.Empty);
-
-            return appBuilder;
-        }
 
         public static IApplicationBuilder UseKafkaFlowRetryEndpoints(
            this IApplicationBuilder appBuilder,
-           string endpointPrefix
-       )
+           string endpointPrefix)
         {
             var retryDurableQueueRepositoryProvider =
                 appBuilder
@@ -36,6 +22,12 @@
             appBuilder.UseRetryEndpoints(retryDurableQueueRepositoryProvider, endpointPrefix);
 
             return appBuilder;
+        }
+
+        public static IApplicationBuilder UseKafkaFlowRetryEndpoints(
+        this IApplicationBuilder appBuilder)
+        {
+            return appBuilder.UseKafkaFlowRetryEndpoints(string.Empty);
         }
 
         public static IApplicationBuilder UseRetryEndpoints(
@@ -70,33 +62,12 @@
         }
 
         public static IApplicationBuilder UseRetryEndpoints(
-                   this IApplicationBuilder appBuilder,
-           IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider
-       )
+                    this IApplicationBuilder appBuilder,
+            IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider
+        )
         {
-            appBuilder.UseMiddleware<RetryMiddleware>(
-                new GetItemsHandler(
-                    retryDurableQueueRepositoryProvider,
-                    new GetItemsRequestDtoReader(),
-                    new GetItemsInputAdapter(),
-                    new GetItemsResponseDtoAdapter(),
-                    string.Empty));
-
-            appBuilder.UseMiddleware<RetryMiddleware>(
-                new PatchItemsHandler(
-                    retryDurableQueueRepositoryProvider,
-                    new UpdateItemsInputAdapter(),
-                    new UpdateItemsResponseDtoAdapter(),
-                    string.Empty));
-
-            appBuilder.UseMiddleware<RetryMiddleware>(
-                new PatchQueuesHandler(
-                    retryDurableQueueRepositoryProvider,
-                    new UpdateQueuesInputAdapter(),
-                    new UpdateQueuesResponseDtoAdapter(),
-                    string.Empty));
-
-            return appBuilder;
+            return appBuilder.UseRetryEndpoints(retryDurableQueueRepositoryProvider, string.Empty);
         }
+
     }
 }

--- a/src/KafkaFlow.Retry.API/AppBuilderExtensions.cs
+++ b/src/KafkaFlow.Retry.API/AppBuilderExtensions.cs
@@ -68,5 +68,35 @@
 
             return appBuilder;
         }
+
+        public static IApplicationBuilder UseRetryEndpoints(
+                   this IApplicationBuilder appBuilder,
+           IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider
+       )
+        {
+            appBuilder.UseMiddleware<RetryMiddleware>(
+                new GetItemsHandler(
+                    retryDurableQueueRepositoryProvider,
+                    new GetItemsRequestDtoReader(),
+                    new GetItemsInputAdapter(),
+                    new GetItemsResponseDtoAdapter(),
+                    string.Empty));
+
+            appBuilder.UseMiddleware<RetryMiddleware>(
+                new PatchItemsHandler(
+                    retryDurableQueueRepositoryProvider,
+                    new UpdateItemsInputAdapter(),
+                    new UpdateItemsResponseDtoAdapter(),
+                    string.Empty));
+
+            appBuilder.UseMiddleware<RetryMiddleware>(
+                new PatchQueuesHandler(
+                    retryDurableQueueRepositoryProvider,
+                    new UpdateQueuesInputAdapter(),
+                    new UpdateQueuesResponseDtoAdapter(),
+                    string.Empty));
+
+            return appBuilder;
+        }
     }
 }

--- a/src/KafkaFlow.Retry.API/Handlers/GetItemsHandler.cs
+++ b/src/KafkaFlow.Retry.API/Handlers/GetItemsHandler.cs
@@ -13,7 +13,7 @@
         private readonly IGetItemsRequestDtoReader getItemsRequestDtoReader;
         private readonly IGetItemsResponseDtoAdapter getItemsResponseDtoAdapter;
         private readonly IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider;
-        private readonly string endpointPrefix;
+        private const string ItemsResource = "items";
 
         public GetItemsHandler(
             IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider,
@@ -31,8 +31,11 @@
             this.retryDurableQueueRepositoryProvider = retryDurableQueueRepositoryProvider;
             this.getItemsRequestDtoReader = getItemsRequestDtoReader;
             this.getItemsResponseDtoAdapter = getItemsResponseDtoAdapter;
-            this.endpointPrefix = endpointPrefix;
+            var extendedPath = string.IsNullOrEmpty(endpointPrefix) ? ItemsResource : endpointPrefix.ExtendResourcePath(ItemsResource);
+            this.ResourcePath = base.ResourcePath.ExtendResourcePath(extendedPath);
         }
+
+        protected override string ResourcePath { get; }
 
         protected override HttpMethod HttpMethod => HttpMethod.GET;
 
@@ -56,20 +59,6 @@
             }
         }
 
-        protected override string ResourcePath
-        {
-            get
-            {
-                string baseResourcePath = base.ResourcePath;
-                if (string.IsNullOrEmpty(endpointPrefix))
-                {
-                    return baseResourcePath.ExtendResourcePath("items");
-                }
-                else
-                {
-                    return baseResourcePath.ExtendResourcePath($"{endpointPrefix}/items");
-                }
-            }
-        }
+
     }
 }

--- a/src/KafkaFlow.Retry.API/Handlers/GetItemsHandler.cs
+++ b/src/KafkaFlow.Retry.API/Handlers/GetItemsHandler.cs
@@ -13,14 +13,13 @@
         private readonly IGetItemsRequestDtoReader getItemsRequestDtoReader;
         private readonly IGetItemsResponseDtoAdapter getItemsResponseDtoAdapter;
         private readonly IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider;
-        private const string ItemsResource = "items";
 
         public GetItemsHandler(
             IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider,
             IGetItemsRequestDtoReader getItemsRequestDtoReader,
             IGetItemsInputAdapter getItemsInputAdapter,
             IGetItemsResponseDtoAdapter getItemsResponseDtoAdapter,
-            string endpointPrefix)
+            string endpointPrefix) : base(endpointPrefix, "items")
         {
             Guard.Argument(retryDurableQueueRepositoryProvider, nameof(retryDurableQueueRepositoryProvider)).NotNull();
             Guard.Argument(getItemsRequestDtoReader, nameof(getItemsRequestDtoReader)).NotNull();
@@ -31,11 +30,7 @@
             this.retryDurableQueueRepositoryProvider = retryDurableQueueRepositoryProvider;
             this.getItemsRequestDtoReader = getItemsRequestDtoReader;
             this.getItemsResponseDtoAdapter = getItemsResponseDtoAdapter;
-            var extendedPath = string.IsNullOrEmpty(endpointPrefix) ? ItemsResource : endpointPrefix.ExtendResourcePath(ItemsResource);
-            this.ResourcePath = base.ResourcePath.ExtendResourcePath(extendedPath);
         }
-
-        protected override string ResourcePath { get; }
 
         protected override HttpMethod HttpMethod => HttpMethod.GET;
 
@@ -58,7 +53,5 @@
                 await this.WriteResponseAsync(response, ex, (int)HttpStatusCode.InternalServerError).ConfigureAwait(false);
             }
         }
-
-
     }
 }

--- a/src/KafkaFlow.Retry.API/Handlers/GetItemsHandler.cs
+++ b/src/KafkaFlow.Retry.API/Handlers/GetItemsHandler.cs
@@ -13,12 +13,14 @@
         private readonly IGetItemsRequestDtoReader getItemsRequestDtoReader;
         private readonly IGetItemsResponseDtoAdapter getItemsResponseDtoAdapter;
         private readonly IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider;
+        private readonly string endpointPrefix;
 
         public GetItemsHandler(
             IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider,
             IGetItemsRequestDtoReader getItemsRequestDtoReader,
             IGetItemsInputAdapter getItemsInputAdapter,
-            IGetItemsResponseDtoAdapter getItemsResponseDtoAdapter)
+            IGetItemsResponseDtoAdapter getItemsResponseDtoAdapter,
+            string endpointPrefix)
         {
             Guard.Argument(retryDurableQueueRepositoryProvider, nameof(retryDurableQueueRepositoryProvider)).NotNull();
             Guard.Argument(getItemsRequestDtoReader, nameof(getItemsRequestDtoReader)).NotNull();
@@ -29,9 +31,8 @@
             this.retryDurableQueueRepositoryProvider = retryDurableQueueRepositoryProvider;
             this.getItemsRequestDtoReader = getItemsRequestDtoReader;
             this.getItemsResponseDtoAdapter = getItemsResponseDtoAdapter;
+            this.endpointPrefix = endpointPrefix;
         }
-
-        protected override string ResourcePath => base.ResourcePath.ExtendResourcePath("items");
 
         protected override HttpMethod HttpMethod => HttpMethod.GET;
 
@@ -52,6 +53,22 @@
             catch (System.Exception ex)
             {
                 await this.WriteResponseAsync(response, ex, (int)HttpStatusCode.InternalServerError).ConfigureAwait(false);
+            }
+        }
+
+        protected override string ResourcePath
+        {
+            get
+            {
+                string baseResourcePath = base.ResourcePath;
+                if (string.IsNullOrEmpty(endpointPrefix))
+                {
+                    return baseResourcePath.ExtendResourcePath("items");
+                }
+                else
+                {
+                    return baseResourcePath.ExtendResourcePath($"{endpointPrefix}/items");
+                }
             }
         }
     }

--- a/src/KafkaFlow.Retry.API/Handlers/PatchItemsHandler.cs
+++ b/src/KafkaFlow.Retry.API/Handlers/PatchItemsHandler.cs
@@ -14,18 +14,20 @@
         private readonly IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider;
         private readonly IUpdateItemsInputAdapter updateItemsInputAdapter;
         private readonly IUpdateItemsResponseDtoAdapter updateItemsResponseDtoAdapter;
+        private readonly string endpointPrefix;
 
         public PatchItemsHandler(
             IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider,
             IUpdateItemsInputAdapter updateItemsInputAdapter,
-            IUpdateItemsResponseDtoAdapter updateItemsResponseDtoAdapter)
+            IUpdateItemsResponseDtoAdapter updateItemsResponseDtoAdapter,
+            string endpointPrefix)
         {
             this.retryDurableQueueRepositoryProvider = retryDurableQueueRepositoryProvider;
             this.updateItemsInputAdapter = updateItemsInputAdapter;
             this.updateItemsResponseDtoAdapter = updateItemsResponseDtoAdapter;
+            this.endpointPrefix = endpointPrefix;
         }
 
-        protected override string ResourcePath => base.ResourcePath.ExtendResourcePath("items");
 
         protected override HttpMethod HttpMethod => HttpMethod.PATCH;
 
@@ -63,6 +65,22 @@
             catch (Exception ex)
             {
                 await this.WriteResponseAsync(response, ex, (int)HttpStatusCode.InternalServerError).ConfigureAwait(false);
+            }
+        }
+
+        protected override string ResourcePath
+        {
+            get
+            {
+                string baseResourcePath = base.ResourcePath;
+                if (string.IsNullOrEmpty(endpointPrefix))
+                {
+                    return base.ResourcePath.ExtendResourcePath("items");
+                }
+                else
+                {
+                    return baseResourcePath.ExtendResourcePath($"{endpointPrefix}/items");
+                }
             }
         }
     }

--- a/src/KafkaFlow.Retry.API/Handlers/PatchItemsHandler.cs
+++ b/src/KafkaFlow.Retry.API/Handlers/PatchItemsHandler.cs
@@ -14,22 +14,17 @@
         private readonly IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider;
         private readonly IUpdateItemsInputAdapter updateItemsInputAdapter;
         private readonly IUpdateItemsResponseDtoAdapter updateItemsResponseDtoAdapter;
-        private const string ItemsResource = "items";
 
         public PatchItemsHandler(
             IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider,
             IUpdateItemsInputAdapter updateItemsInputAdapter,
             IUpdateItemsResponseDtoAdapter updateItemsResponseDtoAdapter,
-            string endpointPrefix)
+            string endpointPrefix) : base(endpointPrefix, "items")
         {
             this.retryDurableQueueRepositoryProvider = retryDurableQueueRepositoryProvider;
             this.updateItemsInputAdapter = updateItemsInputAdapter;
             this.updateItemsResponseDtoAdapter = updateItemsResponseDtoAdapter;
-            var extendedPath = string.IsNullOrEmpty(endpointPrefix) ? ItemsResource : endpointPrefix.ExtendResourcePath(ItemsResource);
-            this.ResourcePath = base.ResourcePath.ExtendResourcePath(extendedPath);
         }
-
-        protected override string ResourcePath { get; }
 
         protected override HttpMethod HttpMethod => HttpMethod.PATCH;
 
@@ -69,7 +64,5 @@
                 await this.WriteResponseAsync(response, ex, (int)HttpStatusCode.InternalServerError).ConfigureAwait(false);
             }
         }
-
-
     }
 }

--- a/src/KafkaFlow.Retry.API/Handlers/PatchItemsHandler.cs
+++ b/src/KafkaFlow.Retry.API/Handlers/PatchItemsHandler.cs
@@ -14,7 +14,7 @@
         private readonly IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider;
         private readonly IUpdateItemsInputAdapter updateItemsInputAdapter;
         private readonly IUpdateItemsResponseDtoAdapter updateItemsResponseDtoAdapter;
-        private readonly string endpointPrefix;
+        private const string ItemsResource = "items";
 
         public PatchItemsHandler(
             IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider,
@@ -25,9 +25,11 @@
             this.retryDurableQueueRepositoryProvider = retryDurableQueueRepositoryProvider;
             this.updateItemsInputAdapter = updateItemsInputAdapter;
             this.updateItemsResponseDtoAdapter = updateItemsResponseDtoAdapter;
-            this.endpointPrefix = endpointPrefix;
+            var extendedPath = string.IsNullOrEmpty(endpointPrefix) ? ItemsResource : endpointPrefix.ExtendResourcePath(ItemsResource);
+            this.ResourcePath = base.ResourcePath.ExtendResourcePath(extendedPath);
         }
 
+        protected override string ResourcePath { get; }
 
         protected override HttpMethod HttpMethod => HttpMethod.PATCH;
 
@@ -68,20 +70,6 @@
             }
         }
 
-        protected override string ResourcePath
-        {
-            get
-            {
-                string baseResourcePath = base.ResourcePath;
-                if (string.IsNullOrEmpty(endpointPrefix))
-                {
-                    return base.ResourcePath.ExtendResourcePath("items");
-                }
-                else
-                {
-                    return baseResourcePath.ExtendResourcePath($"{endpointPrefix}/items");
-                }
-            }
-        }
+
     }
 }

--- a/src/KafkaFlow.Retry.API/Handlers/PatchQueuesHandler.cs
+++ b/src/KafkaFlow.Retry.API/Handlers/PatchQueuesHandler.cs
@@ -14,22 +14,18 @@
         private readonly IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider;
         private readonly IUpdateQueuesInputAdapter updateQueuesInputAdapter;
         private readonly IUpdateQueuesResponseDtoAdapter updateQueuesResponseDtoAdapter;
-        private const string QueuesResource = "queues";
 
         public PatchQueuesHandler(
             IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider,
             IUpdateQueuesInputAdapter updateQueuesInputAdapter,
             IUpdateQueuesResponseDtoAdapter updateQueuesResponseDtoAdapter,
-            string endpointPrefix)
+            string endpointPrefix) : base(endpointPrefix, "queues")
         {
             this.retryDurableQueueRepositoryProvider = retryDurableQueueRepositoryProvider;
             this.updateQueuesInputAdapter = updateQueuesInputAdapter;
             this.updateQueuesResponseDtoAdapter = updateQueuesResponseDtoAdapter;
-            var extendedPath = string.IsNullOrEmpty(endpointPrefix) ? QueuesResource : endpointPrefix.ExtendResourcePath(QueuesResource);
-            this.ResourcePath = base.ResourcePath.ExtendResourcePath(extendedPath);
         }
 
-        protected override string ResourcePath { get; }
 
         protected override HttpMethod HttpMethod => HttpMethod.PATCH;
 
@@ -69,6 +65,5 @@
                 await this.WriteResponseAsync(response, ex, (int)HttpStatusCode.InternalServerError).ConfigureAwait(false);
             }
         }
-
     }
 }

--- a/src/KafkaFlow.Retry.API/Handlers/PatchQueuesHandler.cs
+++ b/src/KafkaFlow.Retry.API/Handlers/PatchQueuesHandler.cs
@@ -14,18 +14,20 @@
         private readonly IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider;
         private readonly IUpdateQueuesInputAdapter updateQueuesInputAdapter;
         private readonly IUpdateQueuesResponseDtoAdapter updateQueuesResponseDtoAdapter;
+        private readonly string endpointPrefix;
 
         public PatchQueuesHandler(
             IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider,
             IUpdateQueuesInputAdapter updateQueuesInputAdapter,
-            IUpdateQueuesResponseDtoAdapter updateQueuesResponseDtoAdapter)
+            IUpdateQueuesResponseDtoAdapter updateQueuesResponseDtoAdapter,
+            string endpointPrefix)
         {
             this.retryDurableQueueRepositoryProvider = retryDurableQueueRepositoryProvider;
             this.updateQueuesInputAdapter = updateQueuesInputAdapter;
             this.updateQueuesResponseDtoAdapter = updateQueuesResponseDtoAdapter;
+            this.endpointPrefix = endpointPrefix;
         }
 
-        protected override string ResourcePath => base.ResourcePath.ExtendResourcePath("queues");
 
         protected override HttpMethod HttpMethod => HttpMethod.PATCH;
 
@@ -63,6 +65,21 @@
             catch (Exception ex)
             {
                 await this.WriteResponseAsync(response, ex, (int)HttpStatusCode.InternalServerError).ConfigureAwait(false);
+            }
+        }
+        protected override string ResourcePath
+        {
+            get
+            {
+                string baseResourcePath = base.ResourcePath;
+                if (string.IsNullOrEmpty(endpointPrefix))
+                {
+                    return base.ResourcePath.ExtendResourcePath("queues");
+                }
+                else
+                {
+                    return baseResourcePath.ExtendResourcePath($"{endpointPrefix}/queues");
+                }
             }
         }
     }

--- a/src/KafkaFlow.Retry.API/Handlers/PatchQueuesHandler.cs
+++ b/src/KafkaFlow.Retry.API/Handlers/PatchQueuesHandler.cs
@@ -14,7 +14,7 @@
         private readonly IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider;
         private readonly IUpdateQueuesInputAdapter updateQueuesInputAdapter;
         private readonly IUpdateQueuesResponseDtoAdapter updateQueuesResponseDtoAdapter;
-        private readonly string endpointPrefix;
+        private const string QueuesResource = "queues";
 
         public PatchQueuesHandler(
             IRetryDurableQueueRepositoryProvider retryDurableQueueRepositoryProvider,
@@ -25,9 +25,11 @@
             this.retryDurableQueueRepositoryProvider = retryDurableQueueRepositoryProvider;
             this.updateQueuesInputAdapter = updateQueuesInputAdapter;
             this.updateQueuesResponseDtoAdapter = updateQueuesResponseDtoAdapter;
-            this.endpointPrefix = endpointPrefix;
+            var extendedPath = string.IsNullOrEmpty(endpointPrefix) ? QueuesResource : endpointPrefix.ExtendResourcePath(QueuesResource);
+            this.ResourcePath = base.ResourcePath.ExtendResourcePath(extendedPath);
         }
 
+        protected override string ResourcePath { get; }
 
         protected override HttpMethod HttpMethod => HttpMethod.PATCH;
 
@@ -67,20 +69,6 @@
                 await this.WriteResponseAsync(response, ex, (int)HttpStatusCode.InternalServerError).ConfigureAwait(false);
             }
         }
-        protected override string ResourcePath
-        {
-            get
-            {
-                string baseResourcePath = base.ResourcePath;
-                if (string.IsNullOrEmpty(endpointPrefix))
-                {
-                    return base.ResourcePath.ExtendResourcePath("queues");
-                }
-                else
-                {
-                    return baseResourcePath.ExtendResourcePath($"{endpointPrefix}/queues");
-                }
-            }
-        }
+
     }
 }

--- a/src/KafkaFlow.Retry.API/RetryRequestHandlerBase.cs
+++ b/src/KafkaFlow.Retry.API/RetryRequestHandlerBase.cs
@@ -3,6 +3,7 @@
     using System.IO;
     using System.Text;
     using System.Threading.Tasks;
+    using Dawn;
     using Microsoft.AspNetCore.Http;
     using Newtonsoft.Json;
 
@@ -11,7 +12,6 @@
 
         private readonly string path;
         private const string RetryResource = "retry";
-        private const string Delimiter = "/";
 
 
         protected JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings()
@@ -24,28 +24,23 @@
 
         protected RetryRequestHandlerBase(string endpointPrefix, string resource)
         {
+            Guard.Argument(resource, nameof(resource)).NotNull().NotEmpty();
 
             if (!string.IsNullOrEmpty(endpointPrefix))
             {
-                this.path = endpointPrefix.ExtendResourcePath(RetryResource);
-                if (!string.IsNullOrEmpty(resource))
-                {
-                    this.path = this.path.ExtendResourcePath(resource);
-                }
+                this.path = this.path
+                    .ExtendResourcePath(endpointPrefix)
+                    .ExtendResourcePath(RetryResource)
+                    .ExtendResourcePath(resource);
+
             }
             else
             {
-                if (!string.IsNullOrEmpty(resource))
-                {
-                    this.path = RetryResource.ExtendResourcePath(resource);
-                }
-                else
-                {
-                    this.path = RetryResource;
-                }
+                this.path = this.path
+                    .ExtendResourcePath(RetryResource)
+                    .ExtendResourcePath(resource);
             }
 
-            this.path = Delimiter + this.path;
         }
 
 

--- a/src/KafkaFlow.Retry.API/RetryRequestHandlerBase.cs
+++ b/src/KafkaFlow.Retry.API/RetryRequestHandlerBase.cs
@@ -29,21 +29,13 @@
             if (!string.IsNullOrEmpty(endpointPrefix))
             {
                 this.path = this.path
-                    .ExtendResourcePath(endpointPrefix)
-                    .ExtendResourcePath(RetryResource)
-                    .ExtendResourcePath(resource);
-
-            }
-            else
-            {
-                this.path = this.path
-                    .ExtendResourcePath(RetryResource)
-                    .ExtendResourcePath(resource);
+                    .ExtendResourcePath(endpointPrefix);
             }
 
+            this.path = this.path
+                .ExtendResourcePath(RetryResource)
+                .ExtendResourcePath(resource);
         }
-
-
 
 
         public virtual async Task<bool> HandleAsync(HttpRequest request, HttpResponse response)

--- a/src/KafkaFlow.Retry.API/RetryRequestHandlerBase.cs
+++ b/src/KafkaFlow.Retry.API/RetryRequestHandlerBase.cs
@@ -10,7 +10,8 @@
     {
 
         private readonly string path;
-        private const string RetryResource = "/retry";
+        private const string RetryResource = "retry";
+        private const string Delimiter = "/";
 
 
         protected JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings()
@@ -24,16 +25,31 @@
         protected RetryRequestHandlerBase(string endpointPrefix, string resource)
         {
 
-            this.path = RetryResource;
-
             if (!string.IsNullOrEmpty(endpointPrefix))
             {
-                this.path = this.path.ExtendResourcePath(endpointPrefix);
+                this.path = endpointPrefix.ExtendResourcePath(RetryResource);
+                if (!string.IsNullOrEmpty(resource))
+                {
+                    this.path = this.path.ExtendResourcePath(resource);
+                }
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(resource))
+                {
+                    this.path = RetryResource.ExtendResourcePath(resource);
+                }
+                else
+                {
+                    this.path = RetryResource;
+                }
             }
 
-            this.path = this.path.ExtendResourcePath(resource);
-
+            this.path = Delimiter + this.path;
         }
+
+
+
 
         public virtual async Task<bool> HandleAsync(HttpRequest request, HttpResponse response)
         {

--- a/src/KafkaFlow.Retry.API/RetryRequestHandlerBase.cs
+++ b/src/KafkaFlow.Retry.API/RetryRequestHandlerBase.cs
@@ -8,6 +8,11 @@
 
     internal abstract class RetryRequestHandlerBase : IHttpRequestHandler
     {
+
+        private readonly string path;
+        private const string RetryResource = "/retry";
+
+
         protected JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings()
         {
             DateTimeZoneHandling = DateTimeZoneHandling.Utc,
@@ -16,7 +21,19 @@
 
         protected abstract HttpMethod HttpMethod { get; }
 
-        protected virtual string ResourcePath => "/retry";
+        protected RetryRequestHandlerBase(string endpointPrefix, string resource)
+        {
+
+            this.path = RetryResource;
+
+            if (!string.IsNullOrEmpty(endpointPrefix))
+            {
+                this.path = this.path.ExtendResourcePath(endpointPrefix);
+            }
+
+            this.path = this.path.ExtendResourcePath(resource);
+
+        }
 
         public virtual async Task<bool> HandleAsync(HttpRequest request, HttpResponse response)
         {
@@ -34,7 +51,7 @@
         {
             var resource = httpRequest.Path.ToUriComponent();
 
-            if (!resource.Equals(this.ResourcePath))
+            if (!resource.Equals(this.path))
             {
                 return false;
             }

--- a/src/KafkaFlow.Retry.UnitTests/API/Handlers/GetItemsHandlerTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/API/Handlers/GetItemsHandlerTests.cs
@@ -61,7 +61,8 @@
                 retryDurableQueueRepositoryProvider.Object,
                 mockGetItemsRequestDtoReader.Object,
                 mockGetItemsInputAdapter.Object,
-                mockGetItemsResponseDtoReader.Object
+                mockGetItemsResponseDtoReader.Object,
+                string.Empty
                 );
 
             // Act
@@ -93,7 +94,8 @@
                 retryQueueDataProvider,
                 getItemsRequestDtoReader,
                 getItemsInputAdapter,
-                getItemsResponseDtoAdapter
+                getItemsResponseDtoAdapter,
+                string.Empty
                 );
 
             // Act

--- a/src/KafkaFlow.Retry.UnitTests/API/Handlers/GetItemsHandlerTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/API/Handlers/GetItemsHandlerTests.cs
@@ -27,11 +27,11 @@
         private readonly Mock<IGetItemsInputAdapter> mockGetItemsInputAdapter = new Mock<IGetItemsInputAdapter>();
         private readonly Mock<IGetItemsRequestDtoReader> mockGetItemsRequestDtoReader = new Mock<IGetItemsRequestDtoReader>();
         private readonly Mock<IGetItemsResponseDtoAdapter> mockGetItemsResponseDtoReader = new Mock<IGetItemsResponseDtoAdapter>();
-        private readonly string resourcePath = "/retry/items";
+        private readonly string resourcePath = "/retry/testendpoint/items";
         private readonly Mock<IRetryDurableQueueRepositoryProvider> retryDurableQueueRepositoryProvider = new Mock<IRetryDurableQueueRepositoryProvider>();
 
         [Fact]
-        public async Task GetItemsHandler_HandleAsync_Success()
+        public async Task GetItemsHandler_HandleAsync_WithEndpointPrefix_Success()
         {
             // Arrange
             var httpContext = this.CreateHttpContext();
@@ -62,7 +62,7 @@
                 mockGetItemsRequestDtoReader.Object,
                 mockGetItemsInputAdapter.Object,
                 mockGetItemsResponseDtoReader.Object,
-                string.Empty
+                "testendpoint"
                 );
 
             // Act
@@ -80,7 +80,7 @@
 
         [Theory]
         [ClassData(typeof(DependenciesThrowingExceptionsData))]
-        public async Task GetItemsHandler_HandleAsync_WithException_ReturnsExpectedStatusCode(
+        public async Task GetItemsHandler_HandleAsync_WithExceptionAndEndpointPrefix_ReturnsExpectedStatusCode(
             IGetItemsRequestDtoReader getItemsRequestDtoReader,
             IGetItemsInputAdapter getItemsInputAdapter,
             IRetryDurableQueueRepositoryProvider retryQueueDataProvider,
@@ -95,7 +95,7 @@
                 getItemsRequestDtoReader,
                 getItemsInputAdapter,
                 getItemsResponseDtoAdapter,
-                string.Empty
+                "testendpoint"
                 );
 
             // Act

--- a/src/KafkaFlow.Retry.UnitTests/API/Handlers/GetItemsHandlerTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/API/Handlers/GetItemsHandlerTests.cs
@@ -27,7 +27,7 @@
         private readonly Mock<IGetItemsInputAdapter> mockGetItemsInputAdapter = new Mock<IGetItemsInputAdapter>();
         private readonly Mock<IGetItemsRequestDtoReader> mockGetItemsRequestDtoReader = new Mock<IGetItemsRequestDtoReader>();
         private readonly Mock<IGetItemsResponseDtoAdapter> mockGetItemsResponseDtoReader = new Mock<IGetItemsResponseDtoAdapter>();
-        private readonly string resourcePath = "/retry/testendpoint/items";
+        private readonly string resourcePath = "/testendpoint/retry/items";
         private readonly Mock<IRetryDurableQueueRepositoryProvider> retryDurableQueueRepositoryProvider = new Mock<IRetryDurableQueueRepositoryProvider>();
 
         [Fact]

--- a/src/KafkaFlow.Retry.UnitTests/API/Handlers/PatchItemsHandlerTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/API/Handlers/PatchItemsHandlerTests.cs
@@ -57,7 +57,8 @@
             var handler = new PatchItemsHandler(
                 retryQueueDataProvider.Object,
                 mockUpdateItemsInputAdapter.Object,
-                mockUpdateItemsResponseDtoAdapter.Object
+                mockUpdateItemsResponseDtoAdapter.Object,
+                string.Empty
                 );
 
             // Act
@@ -103,7 +104,8 @@
             var handler = new PatchItemsHandler(
              Mock.Of<IRetryDurableQueueRepositoryProvider>(),
              Mock.Of<IUpdateItemsInputAdapter>(),
-             Mock.Of<IUpdateItemsResponseDtoAdapter>()
+             Mock.Of<IUpdateItemsResponseDtoAdapter>(),
+             string.Empty
              );
 
             // act
@@ -129,7 +131,8 @@
             var handler = new PatchItemsHandler(
                 retryQueueDataProvider,
                 updateItemsInputAdapter,
-                updateItemsResponseDtoAdapter
+                updateItemsResponseDtoAdapter,
+                string.Empty
                 );
 
             // act

--- a/src/KafkaFlow.Retry.UnitTests/API/Handlers/PatchQueuesHandlerTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/API/Handlers/PatchQueuesHandlerTests.cs
@@ -51,7 +51,8 @@
             var handler = new PatchQueuesHandler(
               retryQueueDataProvider.Object,
               mockUpdateQueuesInputAdapter.Object,
-              mockUpdateQueuesResponseDtoAdapter.Object
+              mockUpdateQueuesResponseDtoAdapter.Object,
+              string.Empty
               );
 
             // Act
@@ -83,7 +84,8 @@
             var handler = new PatchQueuesHandler(
                 retryQueueDataProvider,
                 updateQueuesInputAdapter,
-                updateQueuesResponseDtoAdapter
+                updateQueuesResponseDtoAdapter,
+                string.Empty
                 );
 
             // act

--- a/src/KafkaFlow.Retry.UnitTests/API/RetryRequestHandlerBaseTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/API/RetryRequestHandlerBaseTests.cs
@@ -13,7 +13,7 @@
     public class RetryRequestHandlerBaseTests
     {
         private const string HttpMethod = "GET";
-        private const string ResourcePath = "/retry";
+        private const string ResourcePath = "/retry/resource";
 
         [Fact]
         public async Task RetryRequestHandlerBase_HandleAsync_CallsHandleRequestAsync()
@@ -44,7 +44,7 @@
                 .SetupGet(ctx => ctx.Response)
                 .Returns(httpResponse.Object);
 
-            var surrogate = new RetryRequestHandlerSurrogate(string.Empty, string.Empty);
+            var surrogate = new RetryRequestHandlerSurrogate(string.Empty, "resource");
 
             // Act
             var result = await surrogate.HandleAsync(mockHttpContext.Object.Request, mockHttpContext.Object.Response);
@@ -62,7 +62,7 @@
 
             var httpContext = await HttpContextHelper.CreateContext(ResourcePath, wrongMethod);
 
-            var surrogate = new RetryRequestHandlerSurrogate(string.Empty, string.Empty);
+            var surrogate = new RetryRequestHandlerSurrogate(string.Empty, "resource");
 
             // Act
             var result = await surrogate.HandleAsync(httpContext.Request, httpContext.Response).ConfigureAwait(false);
@@ -79,7 +79,7 @@
 
             var httpContext = await HttpContextHelper.CreateContext(wrongPath, HttpMethod);
 
-            var surrogate = new RetryRequestHandlerSurrogate(string.Empty, string.Empty);
+            var surrogate = new RetryRequestHandlerSurrogate(string.Empty, "resource");
 
             // Act
             var result = await surrogate.HandleAsync(httpContext.Request, httpContext.Response).ConfigureAwait(false);

--- a/src/KafkaFlow.Retry.UnitTests/API/RetryRequestHandlerBaseTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/API/RetryRequestHandlerBaseTests.cs
@@ -44,7 +44,7 @@
                 .SetupGet(ctx => ctx.Response)
                 .Returns(httpResponse.Object);
 
-            var surrogate = new RetryRequestHandlerSurrogate();
+            var surrogate = new RetryRequestHandlerSurrogate(string.Empty, string.Empty);
 
             // Act
             var result = await surrogate.HandleAsync(mockHttpContext.Object.Request, mockHttpContext.Object.Response);
@@ -62,7 +62,7 @@
 
             var httpContext = await HttpContextHelper.CreateContext(ResourcePath, wrongMethod);
 
-            var surrogate = new RetryRequestHandlerSurrogate();
+            var surrogate = new RetryRequestHandlerSurrogate(string.Empty, string.Empty);
 
             // Act
             var result = await surrogate.HandleAsync(httpContext.Request, httpContext.Response).ConfigureAwait(false);
@@ -79,7 +79,7 @@
 
             var httpContext = await HttpContextHelper.CreateContext(wrongPath, HttpMethod);
 
-            var surrogate = new RetryRequestHandlerSurrogate();
+            var surrogate = new RetryRequestHandlerSurrogate(string.Empty, string.Empty);
 
             // Act
             var result = await surrogate.HandleAsync(httpContext.Request, httpContext.Response).ConfigureAwait(false);

--- a/src/KafkaFlow.Retry.UnitTests/API/Surrogate/RetryRequestHandlerSurrogate.cs
+++ b/src/KafkaFlow.Retry.UnitTests/API/Surrogate/RetryRequestHandlerSurrogate.cs
@@ -7,6 +7,10 @@
 
     internal class RetryRequestHandlerSurrogate : RetryRequestHandlerBase
     {
+        public RetryRequestHandlerSurrogate(string endpointPrefix, string resource) : base(endpointPrefix, resource)
+        {
+        }
+
         protected override HttpMethod HttpMethod => HttpMethod.GET;
 
         protected override async Task HandleRequestAsync(HttpRequest request, HttpResponse response)

--- a/src/KafkaFlow.Retry.UnitTests/API/Surrogate/RetryRequestHandlerSurrogate.cs
+++ b/src/KafkaFlow.Retry.UnitTests/API/Surrogate/RetryRequestHandlerSurrogate.cs
@@ -7,6 +7,7 @@
 
     internal class RetryRequestHandlerSurrogate : RetryRequestHandlerBase
     {
+
         public RetryRequestHandlerSurrogate(string endpointPrefix, string resource) : base(endpointPrefix, resource)
         {
         }


### PR DESCRIPTION
# Description

This change is for add an option to add a prefix endpoint on retry items and queues

Fixes #140

## How Has This Been Tested?

This was tested manually, unit tests and integration cannot test this because this is a protected property and I think should stay like this.

## Checklist

-   [ x ] My code follows the style guidelines of this project
-   [ x ] I have performed a self-review of my code
-   [ ] I have added tests to cover my changes
-   [ x ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
