### PR TITLE
build(deps): bump kafkaflow version to "3.0.0"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 # User-specific stuff
 .idea
 
+
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
@@ -428,5 +429,8 @@ healthchecksdb
 
 # Backup folder for Package Reference Convert tool in Visual Studio 2017
 MigrationBackup/
+
+# macOS
+.DS_Store
 
 # End of https://www.gitignore.io/api/rider,linux,windows,visualstudio

--- a/samples/KafkaFlow.Retry.Common.Sample/Helpers/SqlServerHelper.cs
+++ b/samples/KafkaFlow.Retry.Common.Sample/Helpers/SqlServerHelper.cs
@@ -1,7 +1,7 @@
 ﻿namespace KafkaFlow.Retry.Common.Sample.Helpers
 {
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.IO;
     using System.Linq;
     using System.Reflection;

--- a/samples/KafkaFlow.Retry.Sample/Handlers/RetryDurableTestHandler.cs
+++ b/samples/KafkaFlow.Retry.Sample/Handlers/RetryDurableTestHandler.cs
@@ -5,8 +5,7 @@
     using KafkaFlow;
     using KafkaFlow.Retry.Sample.Exceptions;
     using KafkaFlow.Retry.Sample.Messages;
-    using KafkaFlow.TypedHandler;
-
+    
     internal class RetryDurableTestHandler : IMessageHandler<RetryDurableTestMessage>
     {
         public Task Handle(IMessageContext context, RetryDurableTestMessage message)

--- a/samples/KafkaFlow.Retry.Sample/Handlers/RetryForeverTestHandler.cs
+++ b/samples/KafkaFlow.Retry.Sample/Handlers/RetryForeverTestHandler.cs
@@ -5,7 +5,7 @@
     using KafkaFlow;
     using KafkaFlow.Retry.Sample.Exceptions;
     using KafkaFlow.Retry.Sample.Messages;
-    using KafkaFlow.TypedHandler;
+    
 
     internal class RetryForeverTestHandler : IMessageHandler<RetryForeverTestMessage>
     {

--- a/samples/KafkaFlow.Retry.Sample/Handlers/RetrySimpleTestHandler.cs
+++ b/samples/KafkaFlow.Retry.Sample/Handlers/RetrySimpleTestHandler.cs
@@ -5,7 +5,7 @@
     using KafkaFlow;
     using KafkaFlow.Retry.Sample.Exceptions;
     using KafkaFlow.Retry.Sample.Messages;
-    using KafkaFlow.TypedHandler;
+    
 
     internal class RetrySimpleTestHandler : IMessageHandler<RetrySimpleTestMessage>
     {

--- a/samples/KafkaFlow.Retry.Sample/Helpers/KafkaClusterConfigurationBuilderHelper.cs
+++ b/samples/KafkaFlow.Retry.Sample/Helpers/KafkaClusterConfigurationBuilderHelper.cs
@@ -8,8 +8,6 @@
     using KafkaFlow.Retry.Sample.Messages;
     using KafkaFlow.Retry.SqlServer;
     using KafkaFlow.Serializer;
-    using KafkaFlow.TypedHandler;
-
     internal static class KafkaClusterConfigurationBuilderHelper
     {
         internal static IClusterConfigurationBuilder SetupRetryDurableMongoDb(
@@ -41,7 +39,7 @@
                         .WithAutoOffsetReset(AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSerializer<ProtobufNetSerializer>()
+                                .AddDeserializer<ProtobufNetDeserializer>()
                                 .RetryDurable(
                                     configure => configure
                                         .Handle<RetryDurableTestException>()
@@ -129,7 +127,7 @@
                         .WithAutoOffsetReset(AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSerializer<ProtobufNetSerializer>()
+                                .AddDeserializer<ProtobufNetDeserializer>()
                                 .RetryDurable(
                                     configure => configure
                                         .Handle<RetryDurableTestException>()
@@ -209,7 +207,7 @@
                         .WithAutoOffsetReset(AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSerializer<ProtobufNetSerializer>()
+                                .AddDeserializer<ProtobufNetDeserializer>()
                                 .RetryForever(
                                     (configure) => configure
                                         .Handle<RetryForeverTestException>()
@@ -251,7 +249,7 @@
                         .WithAutoOffsetReset(AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSerializer<ProtobufNetSerializer>()
+                                .AddDeserializer<ProtobufNetDeserializer>()
                                 .RetrySimple(
                                     (configure) => configure
                                         .Handle<RetrySimpleTestException>()

--- a/samples/KafkaFlow.Retry.Sample/KafkaFlow.Retry.Sample.csproj
+++ b/samples/KafkaFlow.Retry.Sample/KafkaFlow.Retry.Sample.csproj
@@ -8,15 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="KafkaFlow" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Admin" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Compressor" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.LogHandler.Console" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Serializer" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Serializer.ProtobufNet" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.TypedHandler" Version="2.2.15" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
+    <PackageReference Include="KafkaFlow" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Admin" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.LogHandler.Console" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Serializer.ProtobufNet" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/KafkaFlow.Retry.SchemaRegistry.Sample/Handlers/AvroMessageTestHandler.cs
+++ b/samples/KafkaFlow.Retry.SchemaRegistry.Sample/Handlers/AvroMessageTestHandler.cs
@@ -4,7 +4,6 @@
     using System.Threading.Tasks;
     using global::SchemaRegistry;
     using KafkaFlow.Retry.SchemaRegistry.Sample.Exceptions;
-    using TypedHandler;
 
     public class AvroMessageTestHandler : IMessageHandler<AvroLogMessage>
     {

--- a/samples/KafkaFlow.Retry.SchemaRegistry.Sample/Helpers/KafkaClusterConfigurationBuilderHelper.cs
+++ b/samples/KafkaFlow.Retry.SchemaRegistry.Sample/Helpers/KafkaClusterConfigurationBuilderHelper.cs
@@ -9,7 +9,6 @@
     using KafkaFlow.Retry.SchemaRegistry.Sample.ContractResolvers;
     using KafkaFlow.Retry.SchemaRegistry.Sample.Exceptions;
     using KafkaFlow.Retry.SchemaRegistry.Sample.Handlers;
-    using KafkaFlow.TypedHandler;
     using Newtonsoft.Json;
 
     internal static class KafkaClusterConfigurationBuilderHelper
@@ -47,7 +46,7 @@
                         .WithAutoOffsetReset(AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSchemaRegistryAvroSerializer()
+                                .AddSchemaRegistryAvroDeserializer()
                                 .RetryDurable(
                                     configure => configure
                                         .Handle<RetryDurableTestException>()

--- a/samples/KafkaFlow.Retry.SchemaRegistry.Sample/KafkaFlow.Retry.SchemaRegistry.Sample.csproj
+++ b/samples/KafkaFlow.Retry.SchemaRegistry.Sample/KafkaFlow.Retry.SchemaRegistry.Sample.csproj
@@ -8,16 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="KafkaFlow" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Admin" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Compressor" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.LogHandler.Console" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Serializer" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Serializer.ProtobufNet" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Serializer.SchemaRegistry.ConfluentAvro" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.TypedHandler" Version="2.2.15" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
+    <PackageReference Include="KafkaFlow" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Admin" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.LogHandler.Console" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Serializer.ProtobufNet" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Serializer.SchemaRegistry.ConfluentAvro" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KafkaFlow.Retry.API/KafkaFlow.Retry.API.csproj
+++ b/src/KafkaFlow.Retry.API/KafkaFlow.Retry.API.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KafkaFlow.Retry.IntegrationTests/Core/Bootstrappers/BootstrapperKafka.cs
+++ b/src/KafkaFlow.Retry.IntegrationTests/Core/Bootstrappers/BootstrapperKafka.cs
@@ -11,7 +11,6 @@
     using KafkaFlow.Retry.Postgres;
     using KafkaFlow.Retry.SqlServer;
     using KafkaFlow.Serializer;
-    using KafkaFlow.TypedHandler;
     using Newtonsoft.Json;
 
     internal static class BootstrapperKafka
@@ -71,7 +70,7 @@
                         .WithAutoOffsetReset(KafkaFlow.AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSingleTypeSerializer<NewtonsoftJsonSerializer>(typeof(RetryDurableTestMessage))
+                                .AddSingleTypeDeserializer<NewtonsoftJsonDeserializer>(typeof(RetryDurableTestMessage))
                                 .RetryDurable(
                                     (configure) => configure
                                         .Handle<RetryDurableTestException>()
@@ -147,7 +146,7 @@
                         .WithAutoOffsetReset(KafkaFlow.AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSingleTypeSerializer<NewtonsoftJsonSerializer>(typeof(RetryDurableTestMessage))
+                                .AddSingleTypeDeserializer<NewtonsoftJsonDeserializer>(typeof(RetryDurableTestMessage))
                                 .RetryDurable(
                                     (configure) => configure
                                         .Handle<RetryDurableTestException>()
@@ -221,7 +220,7 @@
                         .WithAutoOffsetReset(KafkaFlow.AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSingleTypeSerializer<NewtonsoftJsonSerializer>(typeof(RetryDurableTestMessage))
+                                .AddSingleTypeDeserializer<NewtonsoftJsonDeserializer>(typeof(RetryDurableTestMessage))
                                 .RetryDurable(
                                     (configure) => configure
                                         .Handle<RetryDurableTestException>()
@@ -297,7 +296,7 @@
                         .WithAutoOffsetReset(KafkaFlow.AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSingleTypeSerializer<NewtonsoftJsonSerializer>(typeof(RetryDurableTestMessage))
+                                .AddSingleTypeDeserializer<NewtonsoftJsonDeserializer>(typeof(RetryDurableTestMessage))
                                 .RetryDurable(
                                     (configure) => configure
                                         .Handle<RetryDurableTestException>()
@@ -373,7 +372,7 @@
                         .WithAutoOffsetReset((KafkaFlow.AutoOffsetReset)AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSingleTypeSerializer<NewtonsoftJsonSerializer>(typeof(RetryDurableTestMessage))
+                                .AddSingleTypeDeserializer<NewtonsoftJsonDeserializer>(typeof(RetryDurableTestMessage))
                                 .RetryDurable(
                                     (configure) => configure
                                         .Handle<RetryDurableTestException>()
@@ -448,7 +447,7 @@
                         .WithAutoOffsetReset((KafkaFlow.AutoOffsetReset)AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSingleTypeSerializer<NewtonsoftJsonSerializer>(typeof(RetryDurableTestMessage))
+                                .AddSingleTypeDeserializer<NewtonsoftJsonDeserializer>(typeof(RetryDurableTestMessage))
                                 .RetryDurable(
                                     (configure) => configure
                                         .Handle<RetryDurableTestException>()
@@ -519,7 +518,7 @@
                         .WithAutoOffsetReset(KafkaFlow.AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSingleTypeSerializer<ProtobufNetSerializer>(typeof(RetryForeverTestMessage))
+                                .AddSingleTypeDeserializer<ProtobufNetDeserializer>(typeof(RetryForeverTestMessage))
                                 .RetryForever(
                                     (configure) => configure
                                         .Handle<RetryForeverTestException>()
@@ -551,7 +550,7 @@
                         .WithAutoOffsetReset(KafkaFlow.AutoOffsetReset.Latest)
                         .AddMiddlewares(
                             middlewares => middlewares
-                                .AddSingleTypeSerializer<NewtonsoftJsonSerializer>(typeof(RetrySimpleTestMessage))
+                                .AddSingleTypeDeserializer<NewtonsoftJsonDeserializer>(typeof(RetrySimpleTestMessage))
                                 .RetrySimple(
                                     (configure) => configure
                                         .Handle<RetrySimpleTestException>()

--- a/src/KafkaFlow.Retry.IntegrationTests/Core/Bootstrappers/BootstrapperSqlServerSchema.cs
+++ b/src/KafkaFlow.Retry.IntegrationTests/Core/Bootstrappers/BootstrapperSqlServerSchema.cs
@@ -1,7 +1,7 @@
 ﻿namespace KafkaFlow.Retry.IntegrationTests.Core.Bootstrappers
 {
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.IO;
     using System.Linq;
     using System.Reflection;

--- a/src/KafkaFlow.Retry.IntegrationTests/Core/Bootstrappers/Fixtures/BootstrapperFixtureTemplate.cs
+++ b/src/KafkaFlow.Retry.IntegrationTests/Core/Bootstrappers/Fixtures/BootstrapperFixtureTemplate.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Threading.Tasks;
     using Dawn;
     using global::Microsoft.Extensions.Configuration;

--- a/src/KafkaFlow.Retry.IntegrationTests/Core/Handlers/RetryDurableTestMessageHandler.cs
+++ b/src/KafkaFlow.Retry.IntegrationTests/Core/Handlers/RetryDurableTestMessageHandler.cs
@@ -5,7 +5,6 @@
     using KafkaFlow.Retry.IntegrationTests.Core.Exceptions;
     using KafkaFlow.Retry.IntegrationTests.Core.Messages;
     using KafkaFlow.Retry.IntegrationTests.Core.Storages;
-    using KafkaFlow.TypedHandler;
 
     internal class RetryDurableTestMessageHandler : IMessageHandler<RetryDurableTestMessage>
     {

--- a/src/KafkaFlow.Retry.IntegrationTests/Core/Handlers/RetryForeverTestMessageHandler.cs
+++ b/src/KafkaFlow.Retry.IntegrationTests/Core/Handlers/RetryForeverTestMessageHandler.cs
@@ -5,7 +5,6 @@
     using KafkaFlow.Retry.IntegrationTests.Core.Exceptions;
     using KafkaFlow.Retry.IntegrationTests.Core.Messages;
     using KafkaFlow.Retry.IntegrationTests.Core.Storages;
-    using KafkaFlow.TypedHandler;
 
     internal class RetryForeverTestMessageHandler : IMessageHandler<RetryForeverTestMessage>
     {

--- a/src/KafkaFlow.Retry.IntegrationTests/Core/Handlers/RetrySimpleTestMessageHandler.cs
+++ b/src/KafkaFlow.Retry.IntegrationTests/Core/Handlers/RetrySimpleTestMessageHandler.cs
@@ -5,7 +5,6 @@
     using KafkaFlow.Retry.IntegrationTests.Core.Exceptions;
     using KafkaFlow.Retry.IntegrationTests.Core.Messages;
     using KafkaFlow.Retry.IntegrationTests.Core.Storages;
-    using KafkaFlow.TypedHandler;
 
     internal class RetrySimpleTestMessageHandler : IMessageHandler<RetrySimpleTestMessage>
     {

--- a/src/KafkaFlow.Retry.IntegrationTests/Core/Storages/Repositories/SqlServerRepository.cs
+++ b/src/KafkaFlow.Retry.IntegrationTests/Core/Storages/Repositories/SqlServerRepository.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Diagnostics;
     using System.Linq;
     using System.Threading.Tasks;

--- a/src/KafkaFlow.Retry.IntegrationTests/KafkaFlow.Retry.IntegrationTests.csproj
+++ b/src/KafkaFlow.Retry.IntegrationTests/KafkaFlow.Retry.IntegrationTests.csproj
@@ -8,31 +8,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="OpenCover" Version="4.7.1221" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="KafkaFlow" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Admin" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Compressor" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.LogHandler.Console" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Serializer" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Serializer.NewtonsoftJson" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.TypedHandler" Version="2.2.15" />
+    <PackageReference Include="KafkaFlow" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Admin" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.LogHandler.Console" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Serializer.NewtonsoftJson" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KafkaFlow.Retry.IntegrationTests/conf/appsettings.json
+++ b/src/KafkaFlow.Retry.IntegrationTests/conf/appsettings.json
@@ -10,7 +10,7 @@
     "RetryQueueItemCollectionName": "RetryQueueItems"
   },
   "SqlServerRepository": {
-    "ConnectionString": "Server=localhost; User ID=SA; Password=SqlSever123123; Pooling=true; Trusted_Connection=true; Integrated Security=true; Min Pool Size=1; Max Pool Size=100; MultipleActiveResultSets=true; Application Name=KafkaFlow Retry Tests;",
+    "ConnectionString": "Server=localhost; User ID=SA; Password=SqlSever123123; Pooling=true; Trusted_Connection=true; Integrated Security=true; Min Pool Size=1; Max Pool Size=100; MultipleActiveResultSets=true; Application Name=KafkaFlow Retry Tests; Encrypt=false;",
     "DatabaseName": "kafka_flow_retry_durable_test",
     "Schema": "dbo"
   },

--- a/src/KafkaFlow.Retry.MongoDb/KafkaFlow.Retry.MongoDb.csproj
+++ b/src/KafkaFlow.Retry.MongoDb/KafkaFlow.Retry.MongoDb.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.12.4" />
+    <PackageReference Include="MongoDB.Driver" Version="2.22.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KafkaFlow.Retry.MongoDb/Model/DboConfigurations.cs
+++ b/src/KafkaFlow.Retry.MongoDb/Model/DboConfigurations.cs
@@ -18,15 +18,15 @@
                     ),
                     new CreateIndexModel<RetryQueueDbo>(
                         Builders<RetryQueueDbo>.IndexKeys.Ascending(x => x.QueueGroupKey),
-                        new CreateIndexOptions{ Unique = true }
+                        new CreateIndexOptions { Unique = true }
                     ),
                     new CreateIndexModel<RetryQueueDbo>(
                         Builders<RetryQueueDbo>.IndexKeys.Ascending(x => x.Status)
                     ),
-                     new CreateIndexModel<RetryQueueDbo>(
+                    new CreateIndexModel<RetryQueueDbo>(
                         Builders<RetryQueueDbo>.IndexKeys.Descending(x => x.CreationDate)
                     ),
-                      new CreateIndexModel<RetryQueueDbo>(
+                    new CreateIndexModel<RetryQueueDbo>(
                         Builders<RetryQueueDbo>.IndexKeys.Ascending(x => x.LastExecution)
                     )
                 }
@@ -53,23 +53,17 @@
 
         internal static void TryRegisterClassMapppings()
         {
-            if (!BsonClassMap.IsClassMapRegistered(typeof(RetryQueueDbo)))
+            BsonClassMap.TryRegisterClassMap<RetryQueueDbo>(cm =>
             {
-                BsonClassMap.RegisterClassMap<RetryQueueDbo>(cm =>
-                    {
-                        cm.AutoMap();
-                        cm.MapIdProperty(q => q.Id).SetIdGenerator(new GuidGenerator());
-                    });
-            }
+                cm.AutoMap();
+                cm.MapIdProperty(q => q.Id).SetIdGenerator(new GuidGenerator());
+            });
 
-            if (!BsonClassMap.IsClassMapRegistered(typeof(RetryQueueItemDbo)))
+            BsonClassMap.TryRegisterClassMap<RetryQueueItemDbo>(cm =>
             {
-                BsonClassMap.RegisterClassMap<RetryQueueItemDbo>(cm =>
-                    {
-                        cm.AutoMap();
-                        cm.MapIdProperty(q => q.Id).SetIdGenerator(new GuidGenerator());
-                    });
-            }
+                cm.AutoMap();
+                cm.MapIdProperty(q => q.Id).SetIdGenerator(new GuidGenerator());
+            });
         }
     }
 }

--- a/src/KafkaFlow.Retry.SqlServer/DbConnectionContext.cs
+++ b/src/KafkaFlow.Retry.SqlServer/DbConnectionContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace KafkaFlow.Retry.SqlServer
 {
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Diagnostics.CodeAnalysis;
     using Dawn;
 

--- a/src/KafkaFlow.Retry.SqlServer/IDbConnection.cs
+++ b/src/KafkaFlow.Retry.SqlServer/IDbConnection.cs
@@ -1,7 +1,7 @@
 ﻿namespace KafkaFlow.Retry.SqlServer
 {
     using System;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
 
     internal interface IDbConnection : IDisposable
     {

--- a/src/KafkaFlow.Retry.SqlServer/KafkaFlow.Retry.SqlServer.csproj
+++ b/src/KafkaFlow.Retry.SqlServer/KafkaFlow.Retry.SqlServer.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KafkaFlow.Retry.SqlServer/KafkaFlow.Retry.SqlServer.csproj
+++ b/src/KafkaFlow.Retry.SqlServer/KafkaFlow.Retry.SqlServer.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KafkaFlow.Retry.SqlServer/Repositories/RetryQueueItemMessageHeaderRepository.cs
+++ b/src/KafkaFlow.Retry.SqlServer/Repositories/RetryQueueItemMessageHeaderRepository.cs
@@ -1,7 +1,7 @@
 namespace KafkaFlow.Retry.SqlServer.Repositories
 {
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Linq;
     using System.Threading.Tasks;
     using Dawn;

--- a/src/KafkaFlow.Retry.SqlServer/Repositories/RetryQueueItemMessageRepository.cs
+++ b/src/KafkaFlow.Retry.SqlServer/Repositories/RetryQueueItemMessageRepository.cs
@@ -1,7 +1,7 @@
 namespace KafkaFlow.Retry.SqlServer.Repositories
 {
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Threading.Tasks;
     using Dawn;
     using KafkaFlow.Retry.SqlServer.Model;

--- a/src/KafkaFlow.Retry.SqlServer/Repositories/RetryQueueItemRepository.cs
+++ b/src/KafkaFlow.Retry.SqlServer/Repositories/RetryQueueItemRepository.cs
@@ -2,7 +2,7 @@ namespace KafkaFlow.Retry.SqlServer.Repositories
 {
     using System;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Linq;
     using System.Threading.Tasks;
     using Dawn;

--- a/src/KafkaFlow.Retry.SqlServer/Repositories/RetryQueueRepository.cs
+++ b/src/KafkaFlow.Retry.SqlServer/Repositories/RetryQueueRepository.cs
@@ -2,7 +2,7 @@ namespace KafkaFlow.Retry.SqlServer.Repositories
 {
     using System;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Threading.Tasks;
     using KafkaFlow.Retry.Durable.Repository.Actions.Read;
     using KafkaFlow.Retry.Durable.Repository.Model;

--- a/src/KafkaFlow.Retry.SqlServer/RetrySchemaCreator.cs
+++ b/src/KafkaFlow.Retry.SqlServer/RetrySchemaCreator.cs
@@ -1,7 +1,7 @@
 ﻿namespace KafkaFlow.Retry.SqlServer
 {
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Threading.Tasks;
     using Dawn;
     using KafkaFlow.Retry.SqlServer.Model.Schema;

--- a/src/KafkaFlow.Retry.UnitTests/KafkaFlow.Retry.UnitTests.csproj
+++ b/src/KafkaFlow.Retry.UnitTests/KafkaFlow.Retry.UnitTests.csproj
@@ -16,21 +16,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="OpenCover" Version="4.7.1221" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.52.0.60960">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.14.0.81108">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/KafkaFlow.Retry/Durable/Definitions/Builders/RetryDurableEmbeddedClusterDefinitionBuilder.cs
+++ b/src/KafkaFlow.Retry/Durable/Definitions/Builders/RetryDurableEmbeddedClusterDefinitionBuilder.cs
@@ -13,8 +13,7 @@
     using KafkaFlow.Retry.Durable.Repository;
     using KafkaFlow.Retry.Durable.Repository.Adapters;
     using KafkaFlow.Retry.Durable.Serializers;
-    using KafkaFlow.TypedHandler;
-
+    
     public class RetryDurableEmbeddedClusterDefinitionBuilder
     {
         private const int DefaultPartitionElection = 0;

--- a/src/KafkaFlow.Retry/KafkaFlow.Retry.csproj
+++ b/src/KafkaFlow.Retry/KafkaFlow.Retry.csproj
@@ -27,13 +27,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KafkaFlow" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Abstractions" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Serializer" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.Serializer.NewtonsoftJson" Version="2.2.15" />
-    <PackageReference Include="KafkaFlow.TypedHandler" Version="2.2.15" />
-    <PackageReference Include="Polly" Version="7.2.2" />
-    <PackageReference Include="Quartz" Version="3.5.0" />
+    <PackageReference Include="KafkaFlow" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Abstractions" Version="3.0.0" />
+    <PackageReference Include="KafkaFlow.Serializer.NewtonsoftJson" Version="3.0.0" />
+    <PackageReference Include="Polly" Version="8.2.0" />
+    <PackageReference Include="Quartz" Version="3.8.0" />
     <PackageReference Include="Dawn.Guard" Version="1.12.0" />
   </ItemGroup>
 </Project>

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -11,11 +11,10 @@ The consumer will use a Simple Retry strategy to retry in case of a given except
 
 By the end of the article, you will know how to use KafkaFlow Retry Extensions to make your Consumers resilient.
 
-
 ## Prerequisites
 
- - [.NET 6.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
- - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- [.NET 6.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
 ## Overview
 
@@ -30,7 +29,7 @@ To connect them, you will be running an Apache Kafka cluster using Docker.
 
 ### 1. Create a folder for your applications
 
-Create a new folder with the name _KafkaFlowRetryuickstart_.
+Create a new folder with the name _KafkaFlowRetryQuickstart_.
 
 ### 2. Setup Apache Kafka
 
@@ -47,6 +46,7 @@ docker-compose up -d
 ### 4. Create Producer Project
 
 Run the following command to create a Console Project named _Producer_.
+
 ```bash
 dotnet new console --name Producer
 ```
@@ -59,8 +59,6 @@ Inside the _Producer_ project directory, run the following commands to install t
 dotnet add package KafkaFlow
 dotnet add package KafkaFlow.Microsoft.DependencyInjection
 dotnet add package KafkaFlow.LogHandler.Console
-dotnet add package KafkaFlow.TypedHandler
-dotnet add package KafkaFlow.Serializer
 dotnet add package KafkaFlow.Serializer.JsonCore
 dotnet add package Microsoft.Extensions.DependencyInjection
 ```
@@ -85,8 +83,8 @@ Replace the content of the _Program.cs_ with the following example:
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
 using KafkaFlow.Producers;
-using KafkaFlow.Serializer;
 using KafkaFlow;
+using KafkaFlow.Serializer;
 using Producer;
 
 var services = new ServiceCollection();
@@ -128,10 +126,10 @@ Console.WriteLine("Message sent!");
 
 ```
 
-
 ### 8. Create Consumer Project
 
 Run the following command to create a Console Project named _Consumer_.
+
 ```bash
 dotnet new console --name Consumer
 ```
@@ -154,8 +152,6 @@ Inside the _Consumer_ project directory, run the following commands to install t
 dotnet add package KafkaFlow
 dotnet add package KafkaFlow.Microsoft.DependencyInjection
 dotnet add package KafkaFlow.LogHandler.Console
-dotnet add package KafkaFlow.TypedHandler
-dotnet add package KafkaFlow.Serializer
 dotnet add package KafkaFlow.Serializer.JsonCore
 dotnet add package Microsoft.Extensions.DependencyInjection
 ```
@@ -174,7 +170,6 @@ Create a new class file named _HelloMessageHandler.cs_ and add the following exa
 
 ```csharp
 using KafkaFlow;
-using KafkaFlow.TypedHandler;
 using Producer;
 
 namespace Consumer;
@@ -215,10 +210,9 @@ Replace the content of the _Program.cs_ with the following example.
 
 ```csharp
 using KafkaFlow;
-using KafkaFlow.Serializer;
 using Microsoft.Extensions.DependencyInjection;
-using KafkaFlow.TypedHandler;
 using KafkaFlow.Retry;
+using KafkaFlow.Serializer;
 using Consumer;
 
 const string topicName = "sample-topic";
@@ -245,7 +239,7 @@ services.AddKafka(kafka => kafka
                                 TimeSpan.FromMilliseconds(Math.Pow(2, retryCount) * 1000)
                             )
                     )
-                    .AddSerializer<JsonCoreSerializer>()
+                    .AddDeserializer<JsonCoreDeserializer>()
                     .AddTypedHandlers(h => h.AddHandler<HelloMessageHandler>())
             )
         )
@@ -268,7 +262,7 @@ await bus.StopAsync();
 From the `KafkaFlowRetryQuickstart` directory:
 
  1. Run the Consumer:
-   
+
 ```bash
 dotnet run --project Consumer/Consumer.csproj 
 ```


### PR DESCRIPTION
# Description

- Upgrade to KafkaFlow 3.0.
- Update Quickstart according to KafkaFlow 3.0
- Refactor [DboConfigurations.cs](src/KafkaFlow.Retry.MongoDb/Model/DboConfigurations.cs) to fix a flaky test.
- Replace `System.Data.SqlClient` with `Microsoft.Data.SqlClient` ([see here why](https://devblogs.microsoft.com/dotnet/introducing-the-new-microsoftdatasqlclient/))
  - Breaking Change: In `System.Data.SqlClient` the Encrypt defaults to false and that has changed in  `Microsoft.Data.SqlClient` ([here](https://github.com/dotnet/SqlClient/blob/main/porting-cheat-sheet.md#functionality-changes))

Fixes #143 

## How Has This Been Tested?

Run tests.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
