### PR TITLE
fix: catch more information about the items inserted with the same sort

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       run: dotnet build --no-restore -c Release KafkaFlow.Retry.sln
       
     - name: Start SqlServer
-      run: docker run -d -p 1433:1433 -e ACCEPT_EULA=${{ env.ACCEPT_EULA }} -e SA_PASSWORD=${{ env.SQLSERVER_SA_PASSWORD }} -e MSSQL_PID=Developer mcr.microsoft.com/mssql/server:2017-latest
+      run: docker run -d -p 1433:1433 -e ACCEPT_EULA=${{ env.ACCEPT_EULA }} -e SA_PASSWORD=${{ env.SQLSERVER_SA_PASSWORD }} -e MSSQL_PID=Developer mcr.microsoft.com/mssql/server:2022-latest
 
     - name: Start Postgres
       run: docker run -d -p 5432:5432 -e POSTGRES_USER=${{ env.POSTGRES_SA_USER }} -e POSTGRES_PASSWORD=${{ env.POSTGRES_SA_PASSWORD }} postgres:latest

--- a/src/KafkaFlow.Retry/Durable/Repository/Model/RetryQueue.cs
+++ b/src/KafkaFlow.Retry/Durable/Repository/Model/RetryQueue.cs
@@ -57,4 +57,15 @@ public class RetryQueue
     {
         _itemsList.Add(item.Sort, item);
     }
+
+    public bool TryAddItem(RetryQueueItem item)
+    {
+        if (_itemsList.TryGetValue(item.Sort, out RetryQueueItem _))
+        {
+            return false;
+        }
+
+        _itemsList.Add(item.Sort, item);
+        return true;
+    }
 }

--- a/src/KafkaFlow.Retry/Durable/Repository/RetryDurableQueueRepository.cs
+++ b/src/KafkaFlow.Retry/Durable/Repository/RetryDurableQueueRepository.cs
@@ -149,15 +149,15 @@ internal class RetryDurableQueueRepository : IRetryDurableQueueRepository
 
             return getQueuesResult?.RetryQueues ?? Enumerable.Empty<RetryQueue>();
         }
+        catch (Exception ex) when (ex is RetryDurableException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
-            var kafkaException = new RetryDurableException(
+            throw new RetryDurableException(
                 new RetryError(RetryErrorCode.DataProviderGetRetryQueues),
                 "An error ocurred getting the retry queues", ex);
-
-            //this.policyBuilder.OnDataProviderException(kafkaException);
-
-            throw kafkaException;
         }
     }
 

--- a/src/KafkaFlow.Retry/Durable/RetryErrorCode.cs
+++ b/src/KafkaFlow.Retry/Durable/RetryErrorCode.cs
@@ -31,4 +31,5 @@ public enum RetryErrorCode
     DataProviderCheckQueuePendingItems = 0204,
     DataProviderGetRetryQueues = 0205,
     DataProviderUpdateItem = 0206,
+    DataProviderGetRetryQueuesSameItemSort = 0207,
 }

--- a/tests/KafkaFlow.Retry.IntegrationTests/conf/appsettings.json
+++ b/tests/KafkaFlow.Retry.IntegrationTests/conf/appsettings.json
@@ -10,7 +10,7 @@
     "RetryQueueItemCollectionName": "RetryQueueItems"
   },
   "SqlServerRepository": {
-    "ConnectionString": "Server=sqlserver.docker.internal; User ID=sa; Password=Finance123.; Pooling=true; Trusted_Connection=false; TrustServerCertificate=true; Integrated Security=false; Min Pool Size=1; Max Pool Size=100; Application Name=KafkaFlow Retry Tests; Encrypt=false;",
+    "ConnectionString": "Server=localhost; User ID=sa; Password=SqlSever123123; Pooling=true; Trusted_Connection=false; TrustServerCertificate=true; Integrated Security=false; Min Pool Size=1; Max Pool Size=100; Application Name=KafkaFlow Retry Tests; Encrypt=false;",
     "DatabaseName": "kafka_flow_retry_durable_test",
     "Schema": "dbo"
   },

--- a/tests/KafkaFlow.Retry.IntegrationTests/conf/appsettings.json
+++ b/tests/KafkaFlow.Retry.IntegrationTests/conf/appsettings.json
@@ -10,7 +10,7 @@
     "RetryQueueItemCollectionName": "RetryQueueItems"
   },
   "SqlServerRepository": {
-    "ConnectionString": "Server=localhost; User ID=SA; Password=SqlSever123123; Pooling=true; Trusted_Connection=true; Integrated Security=true; Min Pool Size=1; Max Pool Size=100; MultipleActiveResultSets=true; Application Name=KafkaFlow Retry Tests; Encrypt=false;",
+    "ConnectionString": "Server=sqlserver.docker.internal; User ID=sa; Password=Finance123.; Pooling=true; Trusted_Connection=false; TrustServerCertificate=true; Integrated Security=false; Min Pool Size=1; Max Pool Size=100; Application Name=KafkaFlow Retry Tests; Encrypt=false;",
     "DatabaseName": "kafka_flow_retry_durable_test",
     "Schema": "dbo"
   },

--- a/tests/KafkaFlow.Retry.UnitTests/Repositories/MongoDb/Adapters/QueuesAdapterTests.cs
+++ b/tests/KafkaFlow.Retry.UnitTests/Repositories/MongoDb/Adapters/QueuesAdapterTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using KafkaFlow.Retry.Durable;
+using KafkaFlow.Retry.Durable.Common;
+using KafkaFlow.Retry.Durable.Repository.Model;
+using KafkaFlow.Retry.MongoDb.Adapters;
+using KafkaFlow.Retry.MongoDb.Adapters.Interfaces;
+using KafkaFlow.Retry.MongoDb.Model;
+using Moq;
+
+namespace KafkaFlow.Retry.UnitTests.Repositories.MongoDb.Adapters;
+
+public class QueuesAdapterTests
+{
+    [Fact]
+    public void Adapt_SameSortOnDiffItems_ThrowsException()
+    {
+        //Arrange
+        var retryQueueId = Guid.Parse("A278590F-299B-4F4C-88F0-1EA3C4588786");
+
+        var mockIItemAdapter = new Mock<IItemAdapter>();
+        mockIItemAdapter
+            .Setup(x => x.Adapt(It.IsAny<RetryQueueItemDbo>()))
+            .Returns(
+                new Queue<RetryQueueItem>(new List<RetryQueueItem>
+                {
+                    new RetryQueueItem(Guid.Parse("A42311CF-2156-4A0C-AD81-EA235AA31B79"),1,DateTime.UtcNow,0,null,null,RetryQueueItemStatus.Waiting,SeverityLevel.Unknown,"1"),
+                    new RetryQueueItem(Guid.Parse("131DEACB-47D5-41BE-9755-9D8C7ED5576B"),1,DateTime.UtcNow,1,null,null,RetryQueueItemStatus.Waiting,SeverityLevel.Unknown,"2"),
+                    new RetryQueueItem(Guid.Parse("4DF0634D-3207-485D-9C5E-100BFF4607C5"),1,DateTime.UtcNow,1,null,null,RetryQueueItemStatus.Waiting,SeverityLevel.Unknown,"3"),
+                    new RetryQueueItem(Guid.Parse("7A1F3DA3-EFFD-46EA-A476-E60881246D5E"),1,DateTime.UtcNow,2,null,null,RetryQueueItemStatus.Waiting,SeverityLevel.Unknown,"4"),
+                    new RetryQueueItem(Guid.Parse("43220795-5BF1-4023-ADA1-789A391B0997"),1,DateTime.UtcNow,3,null,null,RetryQueueItemStatus.Waiting,SeverityLevel.Unknown,"5"),
+                }).Dequeue);
+
+        var adapter = new QueuesAdapter(mockIItemAdapter.Object);
+
+        IEnumerable<RetryQueueDbo> queuesDbo = new List<RetryQueueDbo>
+        {
+            new RetryQueueDbo()
+            {
+                Id = retryQueueId,
+                CreationDate = DateTime.UtcNow,
+                LastExecution = DateTime.UtcNow,
+                QueueGroupKey = "QueueGroupKey",
+                SearchGroupKey = "SearchGroupKey",
+                Status = RetryQueueStatus.Active,
+            }
+        };
+        IEnumerable<RetryQueueItemDbo> itemsDbo = new List<RetryQueueItemDbo>
+        {
+            new RetryQueueItemDbo { RetryQueueId = retryQueueId },
+            new RetryQueueItemDbo { RetryQueueId = retryQueueId },
+            new RetryQueueItemDbo { RetryQueueId = retryQueueId },
+            new RetryQueueItemDbo { RetryQueueId = retryQueueId },
+            new RetryQueueItemDbo { RetryQueueId = retryQueueId },
+        };
+
+        // Act
+        Action act = () => adapter.Adapt(queuesDbo, itemsDbo);
+
+        // Assert
+        act.Should()
+            .Throw<RetryDurableException>()
+            .WithMessage("RetryQueueId:a278590f-299b-4f4c-88f0-1ea3c4588786 RetryQueueItemId:4df0634d-3207-485d-9c5e-100bff4607c5 RetryQueueItemSort:1");
+    }
+}

--- a/tests/KafkaFlow.Retry.UnitTests/Repositories/MongoDb/Adapters/QueuesAdapterTests.cs
+++ b/tests/KafkaFlow.Retry.UnitTests/Repositories/MongoDb/Adapters/QueuesAdapterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using KafkaFlow.Retry.Durable;
 using KafkaFlow.Retry.Durable.Common;

--- a/tests/KafkaFlow.Retry.UnitTests/Repositories/MongoDb/Adapters/QueuesAdapterTests.cs
+++ b/tests/KafkaFlow.Retry.UnitTests/Repositories/MongoDb/Adapters/QueuesAdapterTests.cs
@@ -35,7 +35,7 @@ public class QueuesAdapterTests
 
         IEnumerable<RetryQueueDbo> queuesDbo = new List<RetryQueueDbo>
         {
-            new RetryQueueDbo()
+            new RetryQueueDbo
             {
                 Id = retryQueueId,
                 CreationDate = DateTime.UtcNow,


### PR DESCRIPTION
# Description

There are some scenarios where more than one item is being inserted into the database with the same sort. When polling tries to get queues and queue items to try to process them an exception is thrown and no information about the corrupted queue and queue item is shown.

Fixes 

## How Has This Been Tested?

We place a unit test to guarantee that the correct information is shown.

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
