### PR TITLE
Include message offset into logs

### DIFF
--- a/src/KafkaFlow.Retry/Durable/RetryDurableMiddleware.cs
+++ b/src/KafkaFlow.Retry/Durable/RetryDurableMiddleware.cs
@@ -85,6 +85,7 @@ internal class RetryDurableMiddleware : IMessageMiddleware
                             WaitMilliseconds = waitTime.TotalMilliseconds,
                             PartitionNumber = context.ConsumerContext.Partition,
                             Worker = context.ConsumerContext.WorkerId,
+                            Offset = context.ConsumerContext.Offset,
                             ExceptionType = exception.GetType().FullName,
                             ExceptionMessage = exception.Message
                         });

--- a/src/KafkaFlow.Retry/Forever/RetryForeverMiddleware.cs
+++ b/src/KafkaFlow.Retry/Forever/RetryForeverMiddleware.cs
@@ -58,6 +58,7 @@ internal class RetryForeverMiddleware : IMessageMiddleware
                             WaitMilliseconds = waitTime.TotalMilliseconds,
                             PartitionNumber = context.ConsumerContext.Partition,
                             Worker = context.ConsumerContext.WorkerId,
+                            Offset = context.ConsumerContext.Offset,
                             //Headers = context.HeadersAsJson(),
                             //Message = context.Message.ToJson(),
                             ExceptionType = exception.GetType().FullName

--- a/src/KafkaFlow.Retry/Simple/RetrySimpleMiddleware.cs
+++ b/src/KafkaFlow.Retry/Simple/RetrySimpleMiddleware.cs
@@ -59,6 +59,7 @@ internal class RetrySimpleMiddleware : IMessageMiddleware
                             WaitMilliseconds = waitTime.TotalMilliseconds,
                             PartitionNumber = context.ConsumerContext.Partition,
                             Worker = context.ConsumerContext.WorkerId,
+                            Offset = context.ConsumerContext.Offset,
                             //Headers = context.HeadersAsJson(),
                             //Message = context.Message.ToJson(),
                             ExceptionType = exception.GetType().FullName


### PR DESCRIPTION
# Description

When investigating "stuck in retry" situations it is often required to look up the message that causes retries, and for that knowing the offset is useful.
Unfortunately, currently the Retry middleware only logs the partition number and not the offset of the message in question.

This PR is to add message offset to the logs.
